### PR TITLE
beforePopulate callback

### DIFF
--- a/lib/waterline/query/deferred.js
+++ b/lib/waterline/query/deferred.js
@@ -173,8 +173,8 @@ Deferred.prototype.populate = function(keyName, criteria) {
     // with the associated value.
     var parentKey = this._context.waterline.collections[this._context.identity].attributes[keyName];
 
-    var collectionContext = this._context.waterline.collections[parentKey.collection];
-    callbacks.beforePopulate(collectionContext,criteria.where,function(err){
+    var beforePopulateContext = this._context.waterline.collections[parentKey.model] || this._context.waterline.collections[parentKey.collection];
+    callbacks.beforePopulate(beforePopulateContext,criteria.where,function(err){
       if (err) {return cb(err);}
     });
 

--- a/lib/waterline/query/deferred.js
+++ b/lib/waterline/query/deferred.js
@@ -11,6 +11,7 @@ var normalize = require('../utils/normalize');
 var utils = require('../utils/helpers');
 var acyclicTraversal = require('../utils/acyclicTraversal');
 var hasOwnProperty = utils.object.hasOwnProperty;
+var callbacks = require('../utils/callbacksRunner');
 
 // Alias "catch" as "fail", for backwards compatibility with projects
 // that were created using Q
@@ -171,6 +172,11 @@ Deferred.prototype.populate = function(keyName, criteria) {
     // If it's a belongs_to the adapter needs to know that it should replace the foreign key
     // with the associated value.
     var parentKey = this._context.waterline.collections[this._context.identity].attributes[keyName];
+
+    var collectionContext = this._context.waterline.collections[parentKey.collection];
+    callbacks.beforePopulate(collectionContext,criteria.where,function(err){
+      if (err) {return cb(err);}
+    });
 
     // Build the initial join object that will link this collection to either another collection
     // or to a junction table.

--- a/lib/waterline/query/deferred.js
+++ b/lib/waterline/query/deferred.js
@@ -173,7 +173,7 @@ Deferred.prototype.populate = function(keyName, criteria) {
     // with the associated value.
     var parentKey = this._context.waterline.collections[this._context.identity].attributes[keyName];
 
-    var beforePopulateContext = this._context.waterline.collections[parentKey.model] || this._context.waterline.collections[parentKey.collection];
+    var beforePopulateContext = this._context.waterline.collections[parentKey.model || parentKey.collection];
     callbacks.beforePopulate(beforePopulateContext,criteria.where,function(err){
       if (err) {return cb(err);}
     });

--- a/lib/waterline/utils/callbacks.js
+++ b/lib/waterline/utils/callbacks.js
@@ -11,5 +11,6 @@ module.exports = [
   'afterCreate',
   'beforeDestroy',
   'afterDestroy',
-  'beforeFind'
+  'beforeFind',
+  'beforePopulate'
 ];

--- a/lib/waterline/utils/callbacksRunner.js
+++ b/lib/waterline/utils/callbacksRunner.js
@@ -156,3 +156,20 @@ runner.beforeFind = function(context, values, cb) {
 
   async.eachSeries(context._callbacks.beforeFind, fn, cb);
 };
+
+/**
+ * Run Before Populate Callbacks
+ *
+ * @param {Object} context
+ * @param {Object} values
+ * @param {Function} cb
+ * @api public
+ */
+
+runner.beforePopulate = function(context, values, cb) {
+  var fn = function(item, next) {
+    item(values, next);
+  };
+
+  async.eachSeries(context._callbacks.beforePopulate, fn, cb);
+};


### PR DESCRIPTION
No test yet, will add if we like this.

This feels a little strange: `beforeFind` as defined in as `Employee` model would get triggered by `Employee.find()` whereas `beforePopulate()` in `Employee.js` will get triggered by `Company.populate('employees')`. There's an argument for `beforePopulate()` in `Company.js` being called in that case.

Perhaps that is just a matter of naming convention: `beforePopulate` versus `beforePopulated` or similar..