### PR TITLE
support defaultCriteria

### DIFF
--- a/lib/waterline/query/deferred.js
+++ b/lib/waterline/query/deferred.js
@@ -120,7 +120,7 @@ Deferred.prototype.populate = function(keyName, criteria) {
     parentKey = this._context.waterline.collections[this._context.identity].attributes[keyName];
 
     // Use criteria defaults, if any
-    utils.mergeCriteria(criteria,this._context.waterline.collections[parentKey.model || parentKey.collection].defaultCriteria);
+    criteria = utils.mergeCriteria(criteria,this._context.waterline.collections[parentKey.model || parentKey.collection].defaultCriteria);
 
   } catch (e) {
     throw new Error(

--- a/lib/waterline/query/deferred.js
+++ b/lib/waterline/query/deferred.js
@@ -120,7 +120,7 @@ Deferred.prototype.populate = function(keyName, criteria) {
     parentKey = this._context.waterline.collections[this._context.identity].attributes[keyName];
 
     // Use criteria defaults, if any
-    critiera = utils.mergeCriteria(criteria,this._context.waterline.collections[parentKey.model || parentKey.collection].defaultCriteria);
+    utils.mergeCriteria(criteria,this._context.waterline.collections[parentKey.model || parentKey.collection].defaultCriteria);
 
   } catch (e) {
     throw new Error(

--- a/lib/waterline/query/deferred.js
+++ b/lib/waterline/query/deferred.js
@@ -96,6 +96,7 @@ Deferred.prototype.populate = function(keyName, criteria) {
   var pk = 'id';
   var attr;
   var join;
+  var parentKey;
 
 
   // Normalize sub-criteria
@@ -112,6 +113,14 @@ Deferred.prototype.populate = function(keyName, criteria) {
     // Except make sure `where` exists
     criteria.where = criteria.where === false ? false : (criteria.where || {});
     ////////////////////////////////////////////////////////////////////////
+
+    // Grab the key being populated to check if it is a has many to belongs to
+    // If it's a belongs_to the adapter needs to know that it should replace the foreign key
+    // with the associated value.
+    parentKey = this._context.waterline.collections[this._context.identity].attributes[keyName];
+
+    // Use criteria defaults, if any
+    critiera = utils.mergeCriteria(criteria,this._context.waterline.collections[parentKey.model || parentKey.collection].defaultCriteria);
 
   } catch (e) {
     throw new Error(
@@ -165,12 +174,6 @@ Deferred.prototype.populate = function(keyName, criteria) {
     //   }
     // }, optionalCriteria )
     ////////////////////////////////////////////////////////////////////
-
-
-    // Grab the key being populated to check if it is a has many to belongs to
-    // If it's a belongs_to the adapter needs to know that it should replace the foreign key
-    // with the associated value.
-    var parentKey = this._context.waterline.collections[this._context.identity].attributes[keyName];
 
     // Build the initial join object that will link this collection to either another collection
     // or to a junction table.

--- a/lib/waterline/query/finders/basic.js
+++ b/lib/waterline/query/finders/basic.js
@@ -46,7 +46,7 @@ module.exports = {
     criteria = normalize.criteria(criteria);
 
     // Use criteria defaults, if any
-    critiera = utils.mergeCriteria(criteria,self.defaultCriteria);
+    utils.mergeCriteria(criteria,self.defaultCriteria);
 
     // Return Deferred or pass to adapter
     if(typeof cb !== 'function') {
@@ -228,7 +228,7 @@ module.exports = {
     }
 
     // Use criteria defaults, if any
-    critiera = utils.mergeCriteria(criteria,self.defaultCriteria);
+    utils.mergeCriteria(criteria,self.defaultCriteria);
 
     // Return Deferred or pass to adapter
     if(typeof cb !== 'function') {

--- a/lib/waterline/query/finders/basic.js
+++ b/lib/waterline/query/finders/basic.js
@@ -46,7 +46,7 @@ module.exports = {
     criteria = normalize.criteria(criteria);
 
     // Use criteria defaults, if any
-    utils.mergeCriteria(criteria,self.defaultCriteria);
+    criteria = utils.mergeCriteria(criteria,self.defaultCriteria);
 
     // Return Deferred or pass to adapter
     if(typeof cb !== 'function') {
@@ -228,7 +228,7 @@ module.exports = {
     }
 
     // Use criteria defaults, if any
-    utils.mergeCriteria(criteria,self.defaultCriteria);
+    criteria = utils.mergeCriteria(criteria,self.defaultCriteria);
 
     // Return Deferred or pass to adapter
     if(typeof cb !== 'function') {

--- a/lib/waterline/query/finders/basic.js
+++ b/lib/waterline/query/finders/basic.js
@@ -45,6 +45,9 @@ module.exports = {
     // Normalize criteria
     criteria = normalize.criteria(criteria);
 
+    // Use criteria defaults, if any
+    critiera = utils.mergeCriteria(criteria,self.defaultCriteria);
+
     // Return Deferred or pass to adapter
     if(typeof cb !== 'function') {
       return new Deferred(this, this.findOne, criteria);
@@ -223,6 +226,9 @@ module.exports = {
     if(typeof criteria === 'function' || typeof options === 'function') {
       return usageError('Invalid options specified!', usage, cb);
     }
+
+    // Use criteria defaults, if any
+    critiera = utils.mergeCriteria(criteria,self.defaultCriteria);
 
     // Return Deferred or pass to adapter
     if(typeof cb !== 'function') {

--- a/lib/waterline/utils/helpers.js
+++ b/lib/waterline/utils/helpers.js
@@ -90,23 +90,25 @@ exports.matchMongoId = function matchMongoId(id) {
 
 /**
  * Merge set default criteria.where values
- * Mutates the criteria.where object
+ * returns the updated criteria
  *
- * @object {object} criteria object
- * @object {object} default where values
+ * @param {object} criteria object
+ * @param {object} default where values
+ * @return {object} updated criteria
  * @api public
  */
-exports.mergeCriteria = function mergeCriteria(criteria,defaultCriteria){
+exports.mergeCriteria = function mergeCriteria(originalCriteria,defaultCriteria){
+  var criteria = _.cloneDeep(originalCriteria);
 
   //if criteria is false, always keep it false
   if(!defaultCriteria || criteria.where === false){
-    return;
+    return criteria;
   }
 
   //if criteria wasn't specified, use default
   if(!criteria.where){
     criteria.where = defaultCriteria;
-    return;
+    return criteria;
   }
 
   //handle OR in query criteria
@@ -115,10 +117,10 @@ exports.mergeCriteria = function mergeCriteria(criteria,defaultCriteria){
     criteria.where.or.map(function(option){
       _.defaults(option,defaultCriteria);
     });
-    return;
+    return criteria;
   }
 
   //merge sections
   _.defaults(criteria.where,defaultCriteria);
-  return;
+  return criteria;
 };

--- a/lib/waterline/utils/helpers.js
+++ b/lib/waterline/utils/helpers.js
@@ -109,6 +109,15 @@ exports.mergeCriteria = function mergeCriteria(criteria,defaultCriteria){
     return;
   }
 
+  //handle OR in query criteria
+  //does not currently support OR statements in the default criteria
+  if(criteria.where.or && criteria.where.or.length){
+    criteria.where.or.map(function(option){
+      _.defaults(option,defaultCriteria);
+    });
+    return;
+  }
+
   //merge sections
   _.defaults(criteria.where,defaultCriteria);
   return;

--- a/lib/waterline/utils/helpers.js
+++ b/lib/waterline/utils/helpers.js
@@ -87,3 +87,29 @@ exports.matchMongoId = function matchMongoId(id) {
   ) return false;
   else return id.toString().match(/^[a-fA-F0-9]{24}$/) ? true : false;
 };
+
+/**
+ * Merge set default criteria.where values
+ * Mutates the criteria.where object
+ *
+ * @object {object} criteria object
+ * @object {object} default where values
+ * @api public
+ */
+exports.mergeCriteria = function mergeCriteria(criteria,defaultCriteria){
+
+  //if criteria is false, always keep it false
+  if(!defaultCriteria || criteria.where === false){
+    return;
+  }
+
+  //if criteria wasn't specified, use default
+  if(!criteria.where){
+    criteria.where = defaultCriteria;
+    return;
+  }
+
+  //merge sections
+  _.defaults(criteria.where,defaultCriteria);
+  return;
+};

--- a/test/unit/utils/utils.helpers.js
+++ b/test/unit/utils/utils.helpers.js
@@ -1,0 +1,128 @@
+var assert = require('assert'),
+    _ = require('lodash'),
+    utils = require('../../../lib/waterline/utils/helpers');
+
+describe('utils/helpers', function() {
+
+  describe('.mergeCriteria()', function(){
+    var criteria, defaultCriteria;
+
+    beforeEach(function(){
+      criteria = {
+        where: {
+          id: 123,
+          firstName: 'John'
+        }
+      };
+      defaultCriteria = {
+        deletedAt: null
+      };
+    });
+
+    it('should return false if criteria is false', function(){
+      criteria.where = false;
+      utils.mergeCriteria(criteria,defaultCriteria);
+      assert(_.isEqual(criteria,{
+        where: false
+      }));
+    });
+
+    it('should return criteria unmodified if no default is set', function(){
+      var defaultCriteria;
+      utils.mergeCriteria(criteria,defaultCriteria);
+      assert(_.isEqual(criteria,{
+        where: {
+          id: 123,
+          firstName: 'John'
+        }
+      }));
+    });
+
+    it('should use default if no criteria.where is set', function(){
+      delete criteria.where;
+      utils.mergeCriteria(criteria,defaultCriteria);
+      assert(_.isEqual(criteria,{
+        where: {
+          deletedAt: null
+        }
+      }));
+    });
+
+    it('should apply defaults to every OR options in criteria, if used', function(){
+      criteria.where.or = [
+        { lastName: 'Doe' },
+        { lastName: 'Smith' }
+      ];
+      utils.mergeCriteria(criteria,defaultCriteria);
+      assert(_.isEqual(criteria,{
+        where: {
+          id: 123,
+          firstName: 'John',
+          or: [
+            {
+              lastName: 'Doe',
+              deletedAt: null
+            },
+            {
+              lastName: 'Smith',
+              deletedAt: null
+            }
+          ]
+        }
+      }));
+    });
+
+    it('should not override a OR option with the same key', function(){
+      criteria.where.or = [
+        {
+          lastName: 'Doe',
+          deletedAt: '2017-01-24T08:25:59Z'
+        },
+        { lastName: 'Smith' }
+      ];
+      utils.mergeCriteria(criteria,defaultCriteria);
+      assert(_.isEqual(criteria,{
+        where: {
+          id: 123,
+          firstName: 'John',
+          or: [
+            {
+              lastName: 'Doe',
+              deletedAt: '2017-01-24T08:25:59Z'
+            },
+            {
+              lastName: 'Smith',
+              deletedAt: null
+            }
+          ]
+        }
+      }));
+    });
+
+    it('should append default to criteria if no OR exists', function(){
+      utils.mergeCriteria(criteria,defaultCriteria);
+      assert(_.isEqual(criteria,{
+        where: {
+          id: 123,
+          firstName: 'John',
+          deletedAt: null
+        }
+      }));
+    });
+
+    it('should use criteria value instead of default if both have the same key', function(){
+      criteria.where.deletedAt = '2017-01-24T08:25:59Z';
+      utils.mergeCriteria(criteria,defaultCriteria);
+      assert(_.isEqual(criteria,{
+        where: {
+          id: 123,
+          firstName: 'John',
+          deletedAt: '2017-01-24T08:25:59Z'
+        }
+      }));
+    });
+
+
+  });
+
+});

--- a/test/unit/utils/utils.helpers.js
+++ b/test/unit/utils/utils.helpers.js
@@ -21,7 +21,7 @@ describe('utils/helpers', function() {
 
     it('should return false if criteria is false', function(){
       criteria.where = false;
-      utils.mergeCriteria(criteria,defaultCriteria);
+      criteria = utils.mergeCriteria(criteria,defaultCriteria);
       assert(_.isEqual(criteria,{
         where: false
       }));
@@ -29,7 +29,7 @@ describe('utils/helpers', function() {
 
     it('should return criteria unmodified if no default is set', function(){
       var defaultCriteria;
-      utils.mergeCriteria(criteria,defaultCriteria);
+      criteria = utils.mergeCriteria(criteria,defaultCriteria);
       assert(_.isEqual(criteria,{
         where: {
           id: 123,
@@ -40,7 +40,7 @@ describe('utils/helpers', function() {
 
     it('should use default if no criteria.where is set', function(){
       delete criteria.where;
-      utils.mergeCriteria(criteria,defaultCriteria);
+      criteria = utils.mergeCriteria(criteria,defaultCriteria);
       assert(_.isEqual(criteria,{
         where: {
           deletedAt: null
@@ -53,7 +53,7 @@ describe('utils/helpers', function() {
         { lastName: 'Doe' },
         { lastName: 'Smith' }
       ];
-      utils.mergeCriteria(criteria,defaultCriteria);
+      criteria = utils.mergeCriteria(criteria,defaultCriteria);
       assert(_.isEqual(criteria,{
         where: {
           id: 123,
@@ -80,7 +80,7 @@ describe('utils/helpers', function() {
         },
         { lastName: 'Smith' }
       ];
-      utils.mergeCriteria(criteria,defaultCriteria);
+      criteria = utils.mergeCriteria(criteria,defaultCriteria);
       assert(_.isEqual(criteria,{
         where: {
           id: 123,
@@ -100,7 +100,7 @@ describe('utils/helpers', function() {
     });
 
     it('should append default to criteria if no OR exists', function(){
-      utils.mergeCriteria(criteria,defaultCriteria);
+      criteria = utils.mergeCriteria(criteria,defaultCriteria);
       assert(_.isEqual(criteria,{
         where: {
           id: 123,
@@ -112,7 +112,7 @@ describe('utils/helpers', function() {
 
     it('should use criteria value instead of default if both have the same key', function(){
       criteria.where.deletedAt = '2017-01-24T08:25:59Z';
-      utils.mergeCriteria(criteria,defaultCriteria);
+      criteria = utils.mergeCriteria(criteria,defaultCriteria);
       assert(_.isEqual(criteria,{
         where: {
           id: 123,


### PR DESCRIPTION
Adds support for an options `defaultCriteria` parameter on models. We can use this functionality to enable soft-deletion.