### PR TITLE
don't mutate defaultCriteria

### DIFF
--- a/lib/waterline/utils/helpers.js
+++ b/lib/waterline/utils/helpers.js
@@ -92,13 +92,14 @@ exports.matchMongoId = function matchMongoId(id) {
  * Merge set default criteria.where values
  * returns the updated criteria
  *
- * @param {object} criteria object
- * @param {object} default where values
+ * @param {object} originalCriteria criteria.where sent to query
+ * @param {object} modelDefaultCriteria default where values provided in model
  * @return {object} updated criteria
  * @api public
  */
-exports.mergeCriteria = function mergeCriteria(originalCriteria,defaultCriteria){
+exports.mergeCriteria = function mergeCriteria(originalCriteria,modelDefaultCriteria){
   var criteria = _.cloneDeep(originalCriteria);
+  var defaultCriteria = _.cloneDeep(modelDefaultCriteria);
 
   //if criteria is false, always keep it false
   if(!defaultCriteria || criteria.where === false){


### PR DESCRIPTION
Previously it was possible for `defaultCriteria` on the model to be mutated under certain conditions.